### PR TITLE
Version 3.0.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,14 +4,15 @@
 
 | **Version** | **Support** |
 |:----|:----|
-| v2.0.2 | ✔ |
-| < v2.0.2 | ❌ |
+| v3.0.0 | ✔ |
+| < v3.0.0 | ❌ |
 
 ### Buggy
 
 Version(s) that listed in here were confirmed contains bug(s), and forever not supported (even if listed as a supported version).
 
-*(N/A)*
+- v2.X.X
+- v1.X.X
 
 ## Report Vulnerability
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A module/library to provide a better and more accurate way to determine item typ
 
 ### Getting Started
 
-NodeJS (v8+) & NPM (v6+):
+NodeJS (v10+) & NPM (v6+):
 
 ```powershell
 > npm install @hugoalh/advanced-determine

--- a/README.md
+++ b/README.md
@@ -37,18 +37,19 @@ NodeJS (v8+) & NPM (v6+):
 
 ### API
 
-- `isNull(item, option?)`
 - `isArray(item)`
+- `isBoolean(item, option?)`
 - `isBuffer(item)`
 - `isDate(item)`
 - `isJSON(item)`
+- `isNull(item, option?)`
 - `isNumber(item)`
 - `isRegularExpression(item)`
-- `isString(item, option?)`
-- `isStringLowerCase(item)`
-- `isStringUpperCase(item)`
+- `isString(item)`
 - `isStringASCII(item)`
 - `isStringifyJSON(item)`
+- `isStringLowerCase(item)`
+- `isStringUpperCase(item)`
 - `isUndefined(item, option?)`
 
 ### Example
@@ -57,9 +58,10 @@ NodeJS (v8+) & NPM (v6+):
 const advancedDetermine = require("@hugoalh/advanced-determine");
 
 console.log(advancedDetermine.isString(""));// null
-console.log(advancedDetermine.isString("null", { fuzzyMode: false }));// true
-console.log(advancedDetermine.isString("null", { fuzzyMode: true }));// null
-console.log(advancedDetermine.isNull(""));// true
+console.log(advancedDetermine.isNull("null", { allowStringify: false }));// false
+console.log(advancedDetermine.isNull("null", { allowStringify: true }));// true
+console.log(advancedDetermine.isNull(""));// false
+console.log(advancedDetermine.isNull("", { allowExtend: true }));// true
 console.log(advancedDetermine.isArray([]));// null
 console.log(advancedDetermine.isStringLowerCase("Test word."));// false
 console.log(advancedDetermine.isStringLowerCase("word"));// true

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ NodeJS (v10+) & NPM (v6+):
 - `isNull(item, option?)`
 - `isNumber(item)`
 - `isRegularExpression(item)`
-- `isString(item)`
+- `isString(item, option?)`
 - `isStringASCII(item)`
 - `isStringifyJSON(item)`
 - `isStringLowerCase(item)`

--- a/allis.js
+++ b/allis.js
@@ -15,15 +15,16 @@ const isString = require("./isstring.js");
  */
 function allIs(condition, ...items) {
 	if (isString(condition) == true) {
-		if (condition.indexOf("/") != -1) {
-			return internalService.referenceError(`Invalid path of "type"! (Read the documentation for more information.)`);
+		if (condition.search(/[^a-z]/gui) != -1) {
+			return internalService.referenceError(`Invalid reference of "type"! (Read the documentation for more information.)`);
 		};
+		condition = [condition, undefined];
 	} else if (isArray(condition) == true) {
 		if (isString(condition[0]) != true) {
 			return internalService.typeError(`Invalid type of "type"! Require type of string.`);
 		};
-		if (condition[0].indexOf("/") != -1) {
-			return internalService.referenceError(`Invalid path of "type"! (Read the documentation for more information.)`);
+		if (condition[0].search(/[^a-z]/gui) != -1) {
+			return internalService.referenceError(`Invalid reference of "type"! (Read the documentation for more information.)`);
 		};
 	} else {
 		return internalService.typeError(`Invalid type of "condition"! Require type of string, or array.`);

--- a/allis.js
+++ b/allis.js
@@ -44,7 +44,10 @@ function allIs(condition, ...items) {
 		})
 	);
 	const resultArray = Object.values(resultJSON);
-	if (resultArray.includes(false) == true || resultArray.includes(null) == true) {
+	if (
+		resultArray.includes(false) == true ||
+		resultArray.includes(null) == true
+	) {
 		return false;
 	};
 	return true;

--- a/isboolean.js
+++ b/isboolean.js
@@ -25,11 +25,18 @@ function isBoolean(item, option) {
 			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (typeof item == "boolean" || item === true || item === false) {
+	if (
+		typeof item == "boolean" ||
+		item === true ||
+		item === false
+	) {
 		return true;
 	};
 	if (runtime.allowStringify == true) {
-		if (item === "true" || item === "false") {
+		if (
+			item === "true" ||
+			item === "false"
+		) {
 			return true;
 		};
 	};

--- a/isboolean.js
+++ b/isboolean.js
@@ -20,7 +20,7 @@ function isBoolean(item, option) {
 	if (isJSON(option) == true) {
 		if (option.allowStringify) {
 			if (typeof option.allowStringify != "boolean") {
-				return internalService.typeError(`Invalid type of "option.allowStringify"! Require type of boolean. Ignored this parameter.`);
+				return internalService.typeError(`Invalid type of "option.allowStringify"! Require type of boolean.`);
 			};
 			runtime.allowStringify = option.allowStringify;
 		};

--- a/isboolean.js
+++ b/isboolean.js
@@ -3,32 +3,32 @@
 	Language:
 		NodeJS 14
 ==================*/
+const internalService = require("./internalservice.js");
 const isJSON = require("./isjson.js");
 /**
  * @function isBoolean
  * @description Determine item is type of boolean or not.
  * @param {*} item Item that need to determine.
  * @param {object} [option] Option.
- * @param {boolean} [option.fuzzyMode=false] Enable/Disable fuzzy mode.
+ * @param {boolean} [option.allowStringify=false] Allow stringify type.
  * @returns {boolean} Determine result.
  */
 function isBoolean(item, option) {
 	let runtime = {
-		fuzzyMode: false
+		allowStringify: false
 	};
 	if (isJSON(option) == true) {
-		if (option.fuzzyMode) {
-			if (typeof option.fuzzyMode == "boolean") {
-				runtime.fuzzyMode = option.fuzzyMode;
-			} else {
-				console.warn(`Invalid type of "option.fuzzyMode"! Require type of boolean. Ignored this parameter.`);
+		if (option.allowStringify) {
+			if (typeof option.allowStringify != "boolean") {
+				return internalService.typeError(`Invalid type of "option.allowStringify"! Require type of boolean. Ignored this parameter.`);
 			};
+			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (typeof item == "boolean") {
+	if (typeof item == "boolean" || item === true || item === false) {
 		return true;
 	};
-	if (runtime.fuzzyMode == true) {
+	if (runtime.allowStringify == true) {
 		if (item === "true" || item === "false") {
 			return true;
 		};

--- a/isboolean.js
+++ b/isboolean.js
@@ -25,11 +25,7 @@ function isBoolean(item, option) {
 			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (
-		typeof item == "boolean" ||
-		item === true ||
-		item === false
-	) {
+	if (typeof item == "boolean") {
 		return true;
 	};
 	if (runtime.allowStringify == true) {

--- a/isjson.js
+++ b/isjson.js
@@ -10,7 +10,10 @@
  * @returns {(boolean|null)} Determine result.
  */
 function isJSON(item) {
-	if (typeof item != "object" || item === null) {
+	if (
+		typeof item != "object" ||
+		item === null
+	) {
 		return false;
 	};
 	let bin;
@@ -19,7 +22,10 @@ function isJSON(item) {
 	} catch (error) {
 		return false;
 	};
-	if (Object.keys(item).length == 0 || bin === "{}") {
+	if (
+		Object.keys(item).length == 0 ||
+		bin === "{}"
+	) {
 		return null;
 	};
 	return true;

--- a/isnull.js
+++ b/isnull.js
@@ -7,7 +7,6 @@ const internalService = require("./internalservice.js");
 const isArray = require("./isarray.js");
 const isJSON = require("./isjson.js");
 const isString = require("./isstring.js");
-
 /**
  * @function isNull
  * @alias isNul

--- a/isnull.js
+++ b/isnull.js
@@ -16,6 +16,7 @@ const isString = require("./isString.js");
  * @param {object} [option] Option.
  * @param {boolean} [option.allowExtend=false] Allow to extend determine type of null.
  * @param {boolean} [option.allowStringify=false] Allow stringify type.
+ * @param {boolean} [option.allowWhitespace=true] When option.allowExtend is true, allow whitespace in string.
  * @returns {boolean} Determine result.
  */
 function isNull(item, option) {
@@ -49,7 +50,7 @@ function isNull(item, option) {
 		if (
 			isArray(item) == null ||
 			isJSON(item) == null ||
-			isString(item) == null
+			isString(item, option) == null
 		) {
 			return true;
 		};

--- a/isnull.js
+++ b/isnull.js
@@ -14,8 +14,8 @@ const isString = require("./isString.js");
  * @description Determine item is type of null or not.
  * @param {*} item Item that need to determine.
  * @param {object} [option] Option.
- * @param {boolean} [option.allowStringify=false] Allow stringify type.
  * @param {boolean} [option.allowExtend=false] Allow to extend determine type of null.
+ * @param {boolean} [option.allowStringify=false] Allow stringify type.
  * @returns {boolean} Determine result.
  */
 function isNull(item, option) {

--- a/isnull.js
+++ b/isnull.js
@@ -4,7 +4,10 @@
 		NodeJS 14
 ==================*/
 const internalService = require("./internalservice.js");
+const isArray = require("./isarray.js");
 const isJSON = require("./isjson.js");
+const isString = require("./isString.js");
+
 /**
  * @function isNull
  * @alias isNul
@@ -12,11 +15,13 @@ const isJSON = require("./isjson.js");
  * @param {*} item Item that need to determine.
  * @param {object} [option] Option.
  * @param {boolean} [option.allowStringify=false] Allow stringify type.
+ * @param {boolean} [option.allowExtend=false] Allow to extend determine type of null.
  * @returns {boolean} Determine result.
  */
 function isNull(item, option) {
 	let runtime = {
-		allowStringify: false
+		allowStringify: false,
+		allowExtend: false
 	};
 	if (isJSON(option) == true) {
 		if (option.allowStringify) {
@@ -25,12 +30,27 @@ function isNull(item, option) {
 			};
 			runtime.allowStringify = option.allowStringify;
 		};
+		if (option.allowExtend) {
+			if (typeof option.allowExtend != "boolean") {
+				return internalService.typeError(`Invalid type of "option.allowExtend"! Require type of boolean.`);
+			};
+			runtime.allowExtend = option.allowExtend;
+		};
 	};
 	if (item === null) {
 		return true;
 	};
 	if (runtime.allowStringify == true) {
 		if (item === "null") {
+			return true;
+		};
+	};
+	if (runtime.allowExtend == true) {
+		if (
+			isArray(item) == null ||
+			isJSON(item) == null ||
+			isString(item) == null
+		) {
 			return true;
 		};
 	};

--- a/isnull.js
+++ b/isnull.js
@@ -6,7 +6,7 @@
 const internalService = require("./internalservice.js");
 const isArray = require("./isarray.js");
 const isJSON = require("./isjson.js");
-const isString = require("./isString.js");
+const isString = require("./isstring.js");
 
 /**
  * @function isNull

--- a/isnull.js
+++ b/isnull.js
@@ -3,23 +3,37 @@
 	Language:
 		NodeJS 14
 ==================*/
-const isArray = require("./isarray.js");
+const internalService = require("./internalservice.js");
 const isJSON = require("./isjson.js");
-const isString = require("./isstring.js");
 /**
  * @function isNull
  * @alias isNul
  * @description Determine item is type of null or not.
  * @param {*} item Item that need to determine.
  * @param {object} [option] Option.
+ * @param {boolean} [option.allowStringify=false] Allow stringify type.
  * @returns {boolean} Determine result.
  */
 function isNull(item, option) {
-	return (
-		item === null ||
-		isArray(item) == null ||
-		isJSON(item) == null ||
-		isString(item, option) == null
-	);
+	let runtime = {
+		allowStringify: false
+	};
+	if (isJSON(option) == true) {
+		if (option.allowStringify) {
+			if (typeof option.allowStringify != "boolean") {
+				return internalService.typeError(`Invalid type of "option.allowStringify"! Require type of boolean.`);
+			};
+			runtime.allowStringify = option.allowStringify;
+		};
+	};
+	if (item === null) {
+		return true;
+	};
+	if (runtime.allowStringify == true) {
+		if (item === "null") {
+			return true;
+		};
+	};
+	return false;
 };
 module.exports = isNull;

--- a/isstring.js
+++ b/isstring.js
@@ -3,39 +3,19 @@
 	Language:
 		NodeJS 14
 ==================*/
-const isJSON = require("./isjson.js");
 /**
  * @function isString
  * @alias isStr
  * @description Determine item is type of string or not.
  * @param {*} item Item that need to determine.
- * @param {object} [option] Option.
- * @param {boolean} [option.fuzzyMode=false] Enable/Disable fuzzy mode.
  * @returns {(boolean|null)} Determine result.
  */
-function isString(item, option) {
-	let runtime = {
-		fuzzyMode: false
-	};
-	if (isJSON(option) == true) {
-		if (option.fuzzyMode) {
-			if (typeof option.fuzzyMode == "boolean") {
-				runtime.fuzzyMode = option.fuzzyMode;
-			} else {
-				console.warn(`Invalid type of "option.fuzzyMode"! Require type of boolean. Ignored this parameter.`);
-			};
-		};
-	};
+function isString(item) {
 	if (typeof item != "string") {
 		return false;
 	};
 	if (item.length == 0) {
 		return null;
-	};
-	if (runtime.fuzzyMode == true) {
-		if (item === "null") {
-			return null;
-		};
 	};
 	return true;
 };

--- a/isstring.js
+++ b/isstring.js
@@ -3,16 +3,34 @@
 	Language:
 		NodeJS 14
 ==================*/
+const internalService = require("./internalservice.js");
+const isJSON = require("./isjson.js");
 /**
  * @function isString
  * @alias isStr
  * @description Determine item is type of string or not.
  * @param {*} item Item that need to determine.
+ * @param {object} [option] Option.
+ * @param {boolean} [option.allowWhitespace=true] Allow whitespace.
  * @returns {(boolean|null)} Determine result.
  */
-function isString(item) {
+function isString(item, option) {
+	let runtime = {
+		allowWhitespace: true
+	};
+	if (isJSON(option) == true) {
+		if (option.allowWhitespace) {
+			if (typeof option.allowWhitespace != "boolean") {
+				return internalService.typeError(`Invalid type of "option.allowWhitespace"! Require type of boolean.`);
+			};
+			runtime.allowWhitespace = option.allowWhitespace;
+		};
+	};
 	if (typeof item != "string") {
 		return false;
+	};
+	if (runtime.allowWhitespace == false) {
+		item = item.replace(/[\s\t\r\n]/gu, "");
 	};
 	if (item.length == 0) {
 		return null;

--- a/isstringascii.js
+++ b/isstringascii.js
@@ -8,7 +8,7 @@ const isString = require("./isstring.js");
  * @function isStringASCII
  * @alias isStrASCII
  * @description Determine item is type of ASCII string or not.
- * @param {string} item Item that need to determine.
+ * @param {*} item Item that need to determine.
  * @returns {boolean} Determine result.
  */
 function isStringASCII(item) {

--- a/isstringascii.js
+++ b/isstringascii.js
@@ -3,7 +3,6 @@
 	Language:
 		NodeJS 14
 ==================*/
-const internalService = require("./internalservice.js");
 const isString = require("./isstring.js");
 /**
  * @function isStringASCII
@@ -13,8 +12,8 @@ const isString = require("./isstring.js");
  * @returns {boolean} Determine result.
  */
 function isStringASCII(item) {
-	if (isString(item) == false) {
-		return internalService.typeError(`Invalid type of "item"! Require type of string.`);
+	if (isString(item) != true) {
+		return false;
 	};
 	for (let index = 0; index < item.length; index++) {
 		if (item.charCodeAt(index) > 127) {

--- a/isstringifyjson.js
+++ b/isstringifyjson.js
@@ -8,7 +8,7 @@ const isString = require("./isstring.js");
  * @function isStringifyJSON
  * @alias isStrJSON
  * @description Determine item is type of stringify JSON or not.
- * @param {string} item Item that need to determine.
+ * @param {*} item Item that need to determine.
  * @returns {(boolean|null)} Determine result.
  */
 function isStringifyJSON(item) {

--- a/isstringifyjson.js
+++ b/isstringifyjson.js
@@ -21,7 +21,10 @@ function isStringifyJSON(item) {
 	} catch (error) {
 		return false;
 	};
-	if (Object.keys(bin).length == 0 || item === "{}") {
+	if (
+		Object.keys(bin).length == 0 ||
+		item === "{}"
+	) {
 		return null;
 	};
 	return true;

--- a/isstringifyjson.js
+++ b/isstringifyjson.js
@@ -3,7 +3,6 @@
 	Language:
 		NodeJS 14
 ==================*/
-const internalService = require("./internalservice.js");
 const isString = require("./isstring.js");
 /**
  * @function isStringifyJSON
@@ -13,8 +12,8 @@ const isString = require("./isstring.js");
  * @returns {(boolean|null)} Determine result.
  */
 function isStringifyJSON(item) {
-	if (isString(item) == false) {
-		return internalService.typeError(`Invalid type of "item"! Require type of string.`);
+	if (isString(item) != true) {
+		return false;
 	};
 	let bin;
 	try {

--- a/isstringlowercase.js
+++ b/isstringlowercase.js
@@ -3,7 +3,6 @@
 	Language:
 		NodeJS 14
 ==================*/
-const internalService = require("./internalservice.js");
 const isString = require("./isstring.js");
 /**
  * @function isStringLowerCase
@@ -13,8 +12,8 @@ const isString = require("./isstring.js");
  * @returns {boolean} Determine result.
  */
 function isStringLowerCase(item) {
-	if (isString(item) == false) {
-		return internalService.typeError(`Invalid type of "item"! Require type of string.`);
+	if (isString(item) != true) {
+		return false;
 	};
 	const bin = item.toLowerCase();
 	if (item !== bin) {

--- a/isstringlowercase.js
+++ b/isstringlowercase.js
@@ -8,7 +8,7 @@ const isString = require("./isstring.js");
  * @function isStringLowerCase
  * @alias isStrL
  * @description Determine item is type of lowercase string or not.
- * @param {string} item Item that need to determine.
+ * @param {*} item Item that need to determine.
  * @returns {boolean} Determine result.
  */
 function isStringLowerCase(item) {

--- a/isstringuppercase.js
+++ b/isstringuppercase.js
@@ -8,7 +8,7 @@ const isString = require("./isstring.js");
  * @function isStringUpperCase
  * @alias isStrU
  * @description Determine item is type of uppercase string or not.
- * @param {string} item Item that need to determine.
+ * @param {*} item Item that need to determine.
  * @returns {boolean} Determine result.
  */
 function isStringUpperCase(item) {

--- a/isstringuppercase.js
+++ b/isstringuppercase.js
@@ -3,7 +3,6 @@
 	Language:
 		NodeJS 14
 ==================*/
-const internalService = require("./internalservice.js");
 const isString = require("./isstring.js");
 /**
  * @function isStringUpperCase
@@ -13,8 +12,8 @@ const isString = require("./isstring.js");
  * @returns {boolean} Determine result.
  */
 function isStringUpperCase(item) {
-	if (isString(item) == false) {
-		return internalService.typeError(`Invalid type of "item"! Require type of string.`);
+	if (isString(item) != true) {
+		return false;
 	};
 	const bin = item.toUpperCase();
 	if (item !== bin) {

--- a/isundefined.js
+++ b/isundefined.js
@@ -26,7 +26,10 @@ function isUndefined(item, option) {
 			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (typeof item == "undefined" || item === undefined) {
+	if (
+		typeof item == "undefined" ||
+		item === undefined
+	) {
 		return true;
 	};
 	if (runtime.allowStringify == true) {

--- a/isundefined.js
+++ b/isundefined.js
@@ -3,6 +3,7 @@
 	Language:
 		NodeJS 14
 ==================*/
+const internalService = require("./internalservice.js");
 const isJSON = require("./isjson.js");
 /**
  * @function isUndefined
@@ -10,26 +11,25 @@ const isJSON = require("./isjson.js");
  * @description Determine item is type of undefined or not.
  * @param {*} item Item that need to determine.
  * @param {object} [option] Option.
- * @param {boolean} [option.fuzzyMode=false] Enable/Disable fuzzy mode.
+ * @param {boolean} [option.allowStringify=false] Allow stringify type.
  * @returns {boolean} Determine result.
  */
 function isUndefined(item, option) {
 	let runtime = {
-		fuzzyMode: false
+		allowStringify: false
 	};
 	if (isJSON(option) == true) {
-		if (option.fuzzyMode) {
-			if (typeof option.fuzzyMode == "boolean") {
-				runtime.fuzzyMode = option.fuzzyMode;
-			} else {
-				console.warn(`Invalid type of "option.fuzzyMode"! Require type of boolean. Ignored this parameter.`);
+		if (option.allowStringify) {
+			if (typeof option.allowStringify != "boolean") {
+				return internalService.typeError(`Invalid type of "option.allowStringify"! Require type of boolean.`);
 			};
+			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (typeof item == "undefined") {
+	if (typeof item == "undefined" || item === undefined) {
 		return true;
 	};
-	if (runtime.fuzzyMode == true) {
+	if (runtime.allowStringify == true) {
 		if (item === "undefined") {
 			return true;
 		};

--- a/isundefined.js
+++ b/isundefined.js
@@ -26,10 +26,7 @@ function isUndefined(item, option) {
 			runtime.allowStringify = option.allowStringify;
 		};
 	};
-	if (
-		typeof item == "undefined" ||
-		item === undefined
-	) {
+	if (typeof item == "undefined") {
 		return true;
 	};
 	if (runtime.allowStringify == true) {

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@
 /**
  * @const {string} version
  */
-const version = "2.0.2";
+const version = "3.0.0";
 
 const configuration = require("./configuration.js");
 const isArray = require("./isarray.js");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
 	"name": "@hugoalh/advanced-determine",
-	"version": "2.0.2",
+	"version": "3.0.0",
 	"lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hugoalh/advanced-determine",
-	"version": "2.0.2",
+	"version": "3.0.0",
 	"description": "A module/library to provide a better and more accurate way to determine item type.",
 	"main": "main.js",
 	"repository": {


### PR DESCRIPTION
- Require NodeJS v10+
- Rename option `fuzzyMode` to `allowStringify`
- Add option:
  - `allowExtend` (for function `isNull`)
  - `allowWhitespace` (for function `isString`)
- No longer default ignore type error on option
- Fix function `allIs` parameter `condition` will parse error when input is type of string
- Function `allIs` is now more strict on selecting type determiner
- Function `isNull` no longer determine `[]`, `{}`, and `""` directly, instead require option `allowExtend`
- Function `isString` no longer determine `"null"` with option `fuzzyMode`/`allowStringify` (removed), instead use `isNull` with option `allowStringify`
- Function `isStringifyJSON`, `isStringASCII`, `isStringLowerCase`, and `isStringUpperCase` no longer throw error when input is not type of string, return `false` instead